### PR TITLE
Safe return and log error when bad device name is passed to #out_dev_sel

### DIFF
--- a/omnisynth/src/omnisynth/omni.py
+++ b/omnisynth/src/omnisynth/omni.py
@@ -181,9 +181,6 @@ class Omni():
         dev_name = self.sc.out_dev_table[dev_num]
         self.sc.transmit(command, control, dev_name)
 
-    def sc_server_running(self):
-        return self.sc.serverRunning
-
     # select filter and param value.
     def filter_sel(self, filter_name, value):
         command = "/%s" % self.synth


### PR DESCRIPTION
also, some autoformatting. the actual change:

```python
if dev_num not in self.sc.out_dev_table:
    print(
        f'[ERROR] in #out_dev_sel: Error when selecting device {dev_num}: Device not found')
    return
```

in `#out_dev_sel`